### PR TITLE
Fix error when reporting error

### DIFF
--- a/lib/duo-api.js
+++ b/lib/duo-api.js
@@ -41,14 +41,18 @@ module.exports.prototype.request = function(method, path, params, cb) {
             }
 
             request(req, function (error, response, body) {
-                if (!error && response.statusCode === 200) {
+                if (error) {
+                    reject(error);
+                } else {
+                  if (response.statusCode === 200) {
                     var parsedBody = JSON.parse(body);
                     resolve(parsedBody);
-                } else {
+                  } else {
                     reject(new Error([
                         'Request resulted in status code: ' + response.statusCode,
                         'Response body: ' + body
                     ].join('\n\t')));
+                  }
                 }
             });
         });


### PR DESCRIPTION
The initial conditional `(!error && response.statusCode === 200)` can
return false either because of an error or a non-200 status code.

That is fine, but the `else` logic doesn't check `response` was
defined before using. If there was an `error`, `response` will be undefined.

This updates the logic to check for an `error` first, then check for
200 status code, and report it as an error if it isn't.